### PR TITLE
Remark plugin for parsing tags in Markdown 

### DIFF
--- a/config/gatsby-config.ts
+++ b/config/gatsby-config.ts
@@ -34,6 +34,7 @@ export default {
               disableBgImageOnAlpha: true,
             },
           },
+          `remark-tags-plugin`,
           {
             resolve: `gatsby-remark-orphans`,
             options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10043,13 +10043,6 @@
         "@types/node": "*",
         "@types/unist": "*",
         "@types/vfile-message": "*"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "17.0.31",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-          "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
-        }
       }
     },
     "@types/vfile-message": {
@@ -12198,7 +12191,7 @@
         "camel-case": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-          "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+          "integrity": "sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==",
           "requires": {
             "no-case": "^2.2.0",
             "upper-case": "^1.1.1"
@@ -12207,7 +12200,7 @@
         "lower-case": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+          "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
         },
         "no-case": {
           "version": "2.3.2",
@@ -12220,7 +12213,7 @@
         "pascal-case": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
-          "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+          "integrity": "sha512-qjS4s8rBOJa2Xm0jmxXiyh1+OFf6ekCWOvUaRgAQSktzlTbMotS0nmG9gyYAybCWBcuP4fsBeRCKNwGBnMe2OQ==",
           "requires": {
             "camel-case": "^3.0.0",
             "upper-case-first": "^1.1.0"
@@ -12421,7 +12414,7 @@
     "cheerio": {
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+      "integrity": "sha512-8/MzidM6G/TgRelkzDG13y3Y9LxBjCb+8yOEZ9+wwq5gVF2w2pV0wmHvjfT0RvuxGyR7UEuK36r+yYMbT4uKgA==",
       "requires": {
         "css-select": "~1.2.0",
         "dom-serializer": "~0.1.0",
@@ -12444,7 +12437,7 @@
         "css-select": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-          "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+          "integrity": "sha512-dUQOBoqdR7QwV90WysXPLXG5LO7nhYBgiWVfxF80DKPF8zx1t/pUd2FYy73emg3zrjtM6dzmYgbHKfV2rxiHQA==",
           "requires": {
             "boolbase": "~1.0.0",
             "css-what": "2.1",
@@ -12482,7 +12475,7 @@
         "domutils": {
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+          "integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
           "requires": {
             "dom-serializer": "0",
             "domelementtype": "1"
@@ -13034,7 +13027,7 @@
     "constant-case": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
-      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+      "integrity": "sha512-eS0N9WwmjTqrOmR3o83F5vW8Z+9R1HnVz3xmzT2PMFug9ly+Au/fxRWlEBSb6LcZwspSsEn9Xs1uw9YgzAg1EQ==",
       "requires": {
         "snake-case": "^2.1.0",
         "upper-case": "^1.1.1"
@@ -14225,7 +14218,7 @@
     "dot-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
-      "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+      "integrity": "sha512-HnM6ZlFqcajLsyudHq7LeeLDr2rFAVYtDv/hV5qchQEidSck8j9OPUsXY9KwJv/lHMtYlX4DjRQqwFYa+0r8Ug==",
       "requires": {
         "no-case": "^2.2.0"
       },
@@ -14233,7 +14226,7 @@
         "lower-case": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+          "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
         },
         "no-case": {
           "version": "2.3.2",
@@ -15322,13 +15315,6 @@
       "requires": {
         "@types/node": "*",
         "require-like": ">= 0.1.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "17.0.31",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-          "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
-        }
       }
     },
     "event-emitter": {
@@ -17158,9 +17144,9 @@
       }
     },
     "gatsby-plugin-mdx": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-2.14.0.tgz",
-      "integrity": "sha512-aEAx4KrfSL/A4LFhh5nlOWUZZ2FA70X5xl+j5PiBRFEVTCgSOb8D0XPrHvtwNFYlAhdl/cuH3NcqlbRPJkX+Uw==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-3.20.0.tgz",
+      "integrity": "sha512-v2cFqe1g8lmM745q2DUoqWca0MT/tX++jykBDqpsLDswushpJgUfZeJ8OhSFgBZIfuVk1LoDi5yf4iWfz/UTwQ==",
       "requires": {
         "@babel/core": "^7.15.5",
         "@babel/generator": "^7.15.4",
@@ -17172,13 +17158,13 @@
         "@babel/types": "^7.15.4",
         "camelcase-css": "^2.0.1",
         "change-case": "^3.1.0",
-        "core-js": "^3.17.2",
+        "core-js": "^3.22.3",
         "dataloader": "^1.4.0",
         "debug": "^4.3.1",
         "escape-string-regexp": "^1.0.5",
         "eval": "^0.1.4",
-        "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^2.14.0",
+        "fs-extra": "^10.1.0",
+        "gatsby-core-utils": "^3.20.0",
         "gray-matter": "^4.0.2",
         "json5": "^2.1.3",
         "loader-utils": "^1.4.0",
@@ -17186,6 +17172,7 @@
         "mdast-util-to-string": "^1.1.0",
         "mdast-util-toc": "^3.1.0",
         "mime": "^2.4.6",
+        "mkdirp": "^1.0.4",
         "p-queue": "^6.6.2",
         "pretty-bytes": "^5.3.0",
         "remark": "^10.0.1",
@@ -17201,44 +17188,185 @@
         "unist-util-visit": "^1.4.1"
       },
       "dependencies": {
-        "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.17.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.3.tgz",
-          "integrity": "sha512-yuL5iQA/TbZn+RGAfxQXfi7CNLmKi1f8zInn4IgobuCWcAb7i+zj4TYzQ9l8cEzVyJ89PDGuqxK1xZpUDISesw==",
+        "@babel/compat-data": {
+          "version": "7.20.5",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.5.tgz",
+          "integrity": "sha512-KZXo2t10+/jxmkhNXc7pZTqRvSOIvVv/+lJwHS+B2rErwOyjuVRh60yVpb7liQ1U5t7lLJ1bz+t8tSypUZdm0g=="
+        },
+        "@babel/helper-compilation-targets": {
+          "version": "7.20.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
+          "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
           "requires": {
-            "@babel/compat-data": "^7.17.0",
-            "@babel/helper-compilation-targets": "^7.16.7",
-            "@babel/helper-plugin-utils": "^7.16.7",
-            "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-            "@babel/plugin-transform-parameters": "^7.16.7"
+            "@babel/compat-data": "^7.20.0",
+            "@babel/helper-validator-option": "^7.18.6",
+            "browserslist": "^4.21.3",
+            "semver": "^6.3.0"
           }
+        },
+        "@babel/helper-validator-option": {
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+          "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.20.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.2.tgz",
+          "integrity": "sha512-Ks6uej9WFK+fvIMesSqbAto5dD8Dz4VuuFvGJFKgIGSkJuRGcrwGECPA1fDgQK3/DbExBJpEkTeYeB8geIFCSQ==",
+          "requires": {
+            "@babel/compat-data": "^7.20.1",
+            "@babel/helper-compilation-targets": "^7.20.0",
+            "@babel/helper-plugin-utils": "^7.20.2",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+            "@babel/plugin-transform-parameters": "^7.20.1"
+          },
+          "dependencies": {
+            "@babel/helper-plugin-utils": {
+              "version": "7.20.2",
+              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+              "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ=="
+            }
+          }
+        },
+        "@babel/plugin-transform-parameters": {
+          "version": "7.20.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.5.tgz",
+          "integrity": "sha512-h7plkOmcndIUWXZFLgpbrh2+fXAi47zcUX7IrOQuZdLD0I0KvjJ6cvo3BEcAOsDOcZhVKGJqv07mkSqK0y2isQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.20.2"
+          },
+          "dependencies": {
+            "@babel/helper-plugin-utils": {
+              "version": "7.20.2",
+              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+              "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ=="
+            }
+          }
+        },
+        "@lmdb/lmdb-darwin-arm64": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.3.tgz",
+          "integrity": "sha512-RXwGZ/0eCqtCY8FLTM/koR60w+MXyvBUpToXiIyjOcBnC81tAlTUHrRUavCEWPI9zc9VgvpK3+cbumPyR8BSuA==",
+          "optional": true
+        },
+        "@lmdb/lmdb-darwin-x64": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.3.tgz",
+          "integrity": "sha512-337dNzh5yCdNCTk8kPfoU7jR3otibSlPDGW0vKZT97rKnQMb9tNdto3RtWoGPsQ8hKmlRZpojOJtmwjncq1MoA==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-arm": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.3.tgz",
+          "integrity": "sha512-mU2HFJDGwECkoD9dHQEfeTG5mp8hNS2BCfwoiOpVPMeapjYpQz9Uw3FkUjRZ4dGHWKbin40oWHuL0bk2bCx+Sg==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-arm64": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.3.tgz",
+          "integrity": "sha512-VJw60Mdgb4n+L0fO1PqfB0C7TyEQolJAC8qpqvG3JoQwvyOv6LH7Ib/WE3wxEW9nuHmVz9jkK7lk5HfWWgoO1Q==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-x64": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.3.tgz",
+          "integrity": "sha512-qaReO5aV8griBDsBr8uBF/faO3ieGjY1RY4p8JvTL6Mu1ylLrTVvOONqKFlNaCwrmUjWw5jnf7VafxDAeQHTow==",
+          "optional": true
+        },
+        "@lmdb/lmdb-win32-x64": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.3.tgz",
+          "integrity": "sha512-cK+Elf3RjEzrm3SerAhrFWL5oQAsZSJ/LmjL1joIpTfEP1etJJ9CTRvdaV6XLYAxaEkfdhk/9hOvHLbR9yIhCA==",
+          "optional": true
+        },
+        "browserslist": {
+          "version": "4.21.4",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+          "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001400",
+            "electron-to-chromium": "^1.4.251",
+            "node-releases": "^2.0.6",
+            "update-browserslist-db": "^1.0.9"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001435",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz",
+          "integrity": "sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA=="
         },
         "dataloader": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
           "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
         },
+        "electron-to-chromium": {
+          "version": "1.4.284",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+          "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+        },
         "gatsby-core-utils": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-2.14.0.tgz",
-          "integrity": "sha512-HDMb1XMqysup9raLYWB0wIQU568R9qPounF7iAwjf2esFUVV5mdBTvxEpune/7yG0RmwhNPhgrEZo2rBHeJf7A==",
+          "version": "3.24.0",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.24.0.tgz",
+          "integrity": "sha512-P4tbcYOJ1DSYKRP4gIAR9Xta/d/AzjmsK2C6PzX7sNcGnviDKtAIoeV9sE0kNXOqBfUCez25zmAi2cq8NlaxKw==",
           "requires": {
             "@babel/runtime": "^7.15.4",
             "ci-info": "2.0.0",
             "configstore": "^5.0.1",
+            "fastq": "^1.13.0",
             "file-type": "^16.5.3",
-            "fs-extra": "^10.0.0",
-            "got": "^11.8.2",
-            "node-object-hash": "^2.3.9",
+            "fs-extra": "^10.1.0",
+            "got": "^11.8.5",
+            "import-from": "^4.0.0",
+            "lmdb": "2.5.3",
+            "lock": "^1.1.0",
+            "node-object-hash": "^2.3.10",
             "proper-lockfile": "^4.1.2",
+            "resolve-from": "^5.0.0",
             "tmp": "^0.2.1",
             "xdg-basedir": "^4.0.0"
           }
         },
+        "got": {
+          "version": "11.8.5",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+          "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
+          "requires": {
+            "@sindresorhus/is": "^4.0.0",
+            "@szmarczak/http-timer": "^4.0.5",
+            "@types/cacheable-request": "^6.0.1",
+            "@types/responselike": "^1.0.0",
+            "cacheable-lookup": "^5.0.3",
+            "cacheable-request": "^7.0.2",
+            "decompress-response": "^6.0.0",
+            "http2-wrapper": "^1.0.0-beta.5.2",
+            "lowercase-keys": "^2.0.0",
+            "p-cancelable": "^2.0.0",
+            "responselike": "^2.0.0"
+          }
+        },
+        "lmdb": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.3.tgz",
+          "integrity": "sha512-iBA0cb13CobBSoGJLfZgnrykLlfJipDAnvtf+YwIqqzBEsTeQYsXrHaSBkaHd5wCWeabwrNvhjZoFMUrlo+eLw==",
+          "requires": {
+            "@lmdb/lmdb-darwin-arm64": "2.5.3",
+            "@lmdb/lmdb-darwin-x64": "2.5.3",
+            "@lmdb/lmdb-linux-arm": "2.5.3",
+            "@lmdb/lmdb-linux-arm64": "2.5.3",
+            "@lmdb/lmdb-linux-x64": "2.5.3",
+            "@lmdb/lmdb-win32-x64": "2.5.3",
+            "msgpackr": "^1.5.4",
+            "node-addon-api": "^4.3.0",
+            "node-gyp-build-optional-packages": "5.0.3",
+            "ordered-binary": "^1.2.4",
+            "weak-lru-cache": "^1.2.2"
+          }
+        },
         "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -17254,6 +17382,31 @@
               }
             }
           }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+        },
+        "node-gyp-build-optional-packages": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+          "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA=="
+        },
+        "node-releases": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+          "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "unified": {
           "version": "8.4.2",
@@ -18927,7 +19080,7 @@
     "header-case": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
-      "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+      "integrity": "sha512-i0q9mkOeSuhXw6bGgiQCCBgY/jlZuV/7dZXyZ9c6LcBrqwvT8eT719E9uxE5LiZftdl+z81Ugbg/VvXV4OJOeQ==",
       "requires": {
         "no-case": "^2.2.0",
         "upper-case": "^1.1.3"
@@ -18936,7 +19089,7 @@
         "lower-case": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+          "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
         },
         "no-case": {
           "version": "2.3.2",
@@ -19507,7 +19660,7 @@
     "is-alphanumeric": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
-      "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ="
+      "integrity": "sha512-ZmRL7++ZkcMOfDuWZuMJyIVLr2keE1o/DeNWh1EmgqGhUcV+9BIVsx0BcSBOHTZqzjs4+dISzr2KAeBEWGgXeA=="
     },
     "is-alphanumerical": {
       "version": "1.0.4",
@@ -19725,7 +19878,7 @@
     "is-lower-case": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
-      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+      "integrity": "sha512-+5A1e/WJpLLXZEDlgz4G//WYSHyQBD32qa4Jd3Lw06qQlv3fJHnp3YIHjTQSGzHMgzmVKz2ZP3rBxTHkPw/lxA==",
       "requires": {
         "lower-case": "^1.1.0"
       },
@@ -19733,7 +19886,7 @@
         "lower-case": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+          "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
         }
       }
     },
@@ -19894,7 +20047,7 @@
     "is-upper-case": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
-      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+      "integrity": "sha512-GQYSJMgfeAmVwh9ixyk888l7OIhNAGKtY6QA+IrWlu9MDTCaXmeozOZ2S9Knj7bQwBO/H6J2kb+pbyTUiMNbsw==",
       "requires": {
         "upper-case": "^1.1.0"
       }
@@ -20511,12 +20664,12 @@
     "lodash.assignin": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
+      "integrity": "sha512-yX/rx6d/UTVh7sSVWVSIMjfnz95evAgDFdb1ZozC35I9mSFCkmzptOzevxjgbQUsc78NR44LVHWjsoMQXy9FDg=="
     },
     "lodash.bind": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+      "integrity": "sha512-lxdsn7xxlCymgLYo1gGvVrfHmkjDiyqVv62FAeF2i5ta72BipE1SLxw8hPEPLhD4/247Ijw07UQH7Hq/chT5LA=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -20536,7 +20689,7 @@
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
     "lodash.every": {
       "version": "4.6.0",
@@ -20546,7 +20699,7 @@
     "lodash.filter": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
+      "integrity": "sha512-pXYUy7PR8BCLwX5mgJ/aNtyOvuJTdZAo9EQFUvMIYugqmJxnrYaANvTbgndOzHSCSR0wnlBBfRXJL5SbWxo3FQ=="
     },
     "lodash.flatten": {
       "version": "4.4.0",
@@ -20591,22 +20744,22 @@
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
     },
     "lodash.reduce": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
-      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+      "integrity": "sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw=="
     },
     "lodash.reject": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
-      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
+      "integrity": "sha512-qkTuvgEzYdyhiJBx42YPzPo71R1aEr0z79kAv7Ixg8wPFEjgRgJdUsGMG3Hf3OYSF/kHI79XhNlt+5Ar6OzwxQ=="
     },
     "lodash.some": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+      "integrity": "sha512-j7MJE+TuT51q9ggt4fSgVqro163BEFjAt3u97IqU+JA2DkWl80nFTrowzLpZ/BnpN7rrl0JA/593NAdd8p/scQ=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -20669,7 +20822,7 @@
     "lower-case-first": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
-      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+      "integrity": "sha512-UuxaYakO7XeONbKrZf5FEgkantPf5DUqDayzP5VXZrtRPdH86s4kN47I8B3TW10S4QKiE3ziHNf3kRN//okHjA==",
       "requires": {
         "lower-case": "^1.1.2"
       },
@@ -20677,7 +20830,7 @@
         "lower-case": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+          "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
         }
       }
     },
@@ -22558,7 +22711,7 @@
     "param-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "integrity": "sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==",
       "requires": {
         "no-case": "^2.2.0"
       },
@@ -22566,7 +22719,7 @@
         "lower-case": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+          "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
         },
         "no-case": {
           "version": "2.3.2",
@@ -22761,7 +22914,7 @@
     "path-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
-      "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+      "integrity": "sha512-Ou0N05MioItesaLr9q8TtHVWmJ6fxWdqKB2RohFmNWVyJ+2zeKIeDNWAN6B/Pe7wpzWChhZX6nONYmOnMeJQ/Q==",
       "requires": {
         "no-case": "^2.2.0"
       },
@@ -22769,7 +22922,7 @@
         "lower-case": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+          "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
         },
         "no-case": {
           "version": "2.3.2",
@@ -24593,7 +24746,7 @@
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+          "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
         },
         "parse-entities": {
           "version": "1.2.2",
@@ -25064,7 +25217,7 @@
     "replace-ext": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+      "integrity": "sha512-vuNYXC7gG7IeVNBC1xUllqCcZKRbJoSPOBhnTEcAIiKCsbuef6zO3F0Rve3isPMMoNoQRWjQwbAgAjHUHniyEA=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -25079,7 +25232,7 @@
     "require-like": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz",
-      "integrity": "sha1-rW8wwTvs15cBDEaK+ndcDAprR/o="
+      "integrity": "sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A=="
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -25631,7 +25784,7 @@
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -25708,7 +25861,7 @@
     "sentence-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
-      "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+      "integrity": "sha512-ENl7cYHaK/Ktwk5OTD+aDbQ3uC8IByu/6Bkg+HDv8Mm+XnBnppVNalcfJTNsp1ibstKh030/JKQQWglDvtKwEQ==",
       "requires": {
         "no-case": "^2.2.0",
         "upper-case-first": "^1.1.2"
@@ -25717,7 +25870,7 @@
         "lower-case": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+          "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
         },
         "no-case": {
           "version": "2.3.2",
@@ -25995,7 +26148,7 @@
     "snake-case": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
-      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "integrity": "sha512-FMR5YoPFwOLuh4rRz92dywJjyKYZNLpMn1R5ujVpIYkbA9p01fq8RMg0FkO4M+Yobt4MjHeLTJVm5xFFBHSV2Q==",
       "requires": {
         "no-case": "^2.2.0"
       },
@@ -26003,7 +26156,7 @@
         "lower-case": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+          "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
         },
         "no-case": {
           "version": "2.3.2",
@@ -26378,12 +26531,12 @@
         "source-list-map": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz",
-          "integrity": "sha1-mIkBnRAkzOVc3AaUmDN+9hhqEaE="
+          "integrity": "sha512-FqR2O+cX+toUD3ULVIgTtiqYIqPnA62ehJD47mf4LG1PZCB+xmIa3gcTEhegGbP22aRPh88dJSdgDIolrvSxBQ=="
         },
         "webpack-sources": {
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
-          "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
+          "integrity": "sha512-iqanNZjOHLdPn/R0e/nKVn90dm4IsUMxKam0MZD1btWhFub/Cdo1nWdMio6yEqBc0F8mEieOjc+jfBSXwna94Q==",
           "requires": {
             "source-list-map": "^1.1.1",
             "source-map": "~0.5.3"
@@ -26674,7 +26827,7 @@
     "strip-bom-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="
     },
     "strip-comments": {
       "version": "1.0.2",
@@ -26847,7 +27000,7 @@
     "swap-case": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
-      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+      "integrity": "sha512-BAmWG6/bx8syfc6qXPprof3Mn5vQgf5dwdUNJhsNqU9WdPt5P+ES/wQ5bxfijy8zwZgZZHslC3iAsxsuQMCzJQ==",
       "requires": {
         "lower-case": "^1.1.1",
         "upper-case": "^1.1.1"
@@ -26856,7 +27009,7 @@
         "lower-case": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+          "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
         }
       }
     },
@@ -27220,7 +27373,7 @@
     "title-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
-      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "integrity": "sha512-EkJoZ2O3zdCz3zJsYCsxyq2OC5hrxR9mfdd5I+w8h/tmFfeOxJ+vvkxsKxdmN0WtS9zLdHEgfgVOiMVgv+Po4Q==",
       "requires": {
         "no-case": "^2.2.0",
         "upper-case": "^1.0.3"
@@ -27229,7 +27382,7 @@
         "lower-case": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+          "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
         },
         "no-case": {
           "version": "2.3.2",
@@ -27887,6 +28040,15 @@
       "dev": true,
       "optional": true
     },
+    "update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
+    },
     "update-notifier": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
@@ -27964,12 +28126,12 @@
     "upper-case": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+      "integrity": "sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA=="
     },
     "upper-case-first": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
-      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+      "integrity": "sha512-wINKYvI3Db8dtjikdAqoBbZoP6Q+PZUyfMR7pmwHzjC2quzSkUq5DmPrTtPEqHaz8AGtmsB4TqwapMTM1QAQOQ==",
       "requires": {
         "upper-case": "^1.1.1"
       }
@@ -29020,7 +29182,7 @@
     "x-is-string": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+      "integrity": "sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "gatsby": "^4.17.2",
     "gatsby-plugin-image": "^2.13.0",
     "gatsby-plugin-manifest": "^4.13.0",
-    "gatsby-plugin-mdx": "^2.10.1",
+    "gatsby-plugin-mdx": "^3.10.1",
     "gatsby-plugin-offline": "^5.13.0",
     "gatsby-plugin-react-helmet": "^5.13.0",
     "gatsby-plugin-sass": "^5.13.0",

--- a/plugins/remark-tags-plugin/gatsby-node.js
+++ b/plugins/remark-tags-plugin/gatsby-node.js
@@ -1,0 +1,18 @@
+const graphQLTypes = `
+type Tags implements Node {
+  category: String!
+  keywords: [Keyword]!
+  children: [Node]!
+}
+type Keyword {
+  keyword: String!
+  anchors: [Anchor]!
+}
+type Anchor {
+  id: String!
+  mdx: Mdx @link(by: "id" from: "mdx")
+}
+`
+exports.createSchemaCustomization = ({ actions }) => {
+    actions.createTypes(graphQLTypes)
+  }

--- a/plugins/remark-tags-plugin/index.js
+++ b/plugins/remark-tags-plugin/index.js
@@ -16,7 +16,7 @@ const visitTypes = [
 ]
 
 function traverse(node, tags) {
-  const regexp = new RegExp(/\((.*?)\):{{#([\w\s]*)}}/, "g")
+  const regexp = new RegExp(/(?:\(([^\(\)]*)\)|\({2}([^\(\)]*)\){2}):{{#([\w\s]+)}}/, "g")
 
   const children = node.children.map(child => {
     if (child.type !== "text") return child
@@ -31,8 +31,8 @@ function traverse(node, tags) {
 
 function extractData(match, regexp, tags) {
   const [text, category, anchorId] = [
-    match[1],
-    match[2],
+    match[1] || match[2],
+    match[3],
     `tag-anchor-${nanoid()}`,
   ]
   const { displayText, keyword } = extractKeyword(text)

--- a/plugins/remark-tags-plugin/index.js
+++ b/plugins/remark-tags-plugin/index.js
@@ -1,0 +1,108 @@
+const visit = require(`unist-util-visit`)
+const u = require("unist-builder")
+import { v4 as nanoid } from "uuid"
+import { extractElement } from "./utils"
+
+const visitTypes = [
+  "heading",
+  "paragraph",
+  "blockquote",
+  "list",
+  "listItem",
+  "emphasis",
+  "strong",
+  "link",
+  "linkReference",
+]
+
+function traverse(node, tags) {
+  const regexp = new RegExp(/\((.*?)\):{{#([\w\s]*)}}/, "g")
+
+  const children = node.children.map(child => {
+    if (child.type !== "text") return child
+    const match = regexp.exec(child.value)
+    if (match === null) return child
+
+    return u("jsx", extractData(match, regexp, tags))
+  })
+
+  node.children = children
+}
+
+function extractData(match, regexp, tags) {
+  const [text, category, anchorId] = [
+    match[1],
+    match[2],
+    `tag-anchor-${nanoid()}`,
+  ]
+  const { displayText, keyword } = extractKeyword(text)
+
+  tags.push({ keyword, category, anchorId })
+
+  const nextMatch = regexp.exec(match.input)
+
+  return insertAnchorElement(
+    nextMatch ? extractData(nextMatch, regexp, tags) : match.input,
+    match,
+    anchorId,
+    displayText
+  )
+}
+
+function extractKeyword(string) {
+  const [displayText, keyword] = string.split("|")
+  return { displayText, keyword: keyword || displayText }
+}
+
+function insertAnchorElement(string, match, anchorId, displayText) {
+  const [before, after] = [
+    string.substring(0, match.index),
+    string.substring(match.index + match[0].length),
+  ]
+  return `${before}<span style="font-family: inherit;" id="${anchorId}">${displayText}</span>${after}`
+}
+
+async function createNodesFromAnchors(anchors, util) {
+  for (const currentAnchor of anchors) {
+    const existingTag = util.getNode(
+      util.createNodeId(`TAGS__${currentAnchor.category}`)
+    )
+
+    const [existingKeyword, otherKeywords] = extractElement(
+      existingTag?.keywords || [],
+      keyword => keyword.keyword === currentAnchor.keyword
+    )
+
+    const tagContent = {
+      ...(existingTag || { category: currentAnchor.category }),
+      keywords: [
+        {
+          keyword: currentAnchor.keyword,
+          anchors: [
+            ...(existingKeyword?.anchors || []),
+            { id: currentAnchor.anchorId, mdx: util.markdownNode.id },
+          ],
+        },
+        ...otherKeywords,
+      ],
+      children: [],
+    }
+
+    const tagNode = {
+      ...tagContent,
+      id: util.createNodeId(`TAGS__${tagContent.category}`),
+      internal: {
+        type: "Tags",
+        contentDigest: util.createContentDigest(tagContent),
+      },
+    }
+    await util.actions.createNode(tagNode)
+  }
+}
+
+module.exports = async ({ markdownAST: tree, ...util }) => {
+  const tags = []
+  visit(tree, visitTypes, node => traverse(node, tags))
+  await createNodesFromAnchors(tags, util)
+  return tree
+}

--- a/plugins/remark-tags-plugin/package.json
+++ b/plugins/remark-tags-plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "remark-tags-plugin",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/plugins/remark-tags-plugin/utils.js
+++ b/plugins/remark-tags-plugin/utils.js
@@ -1,0 +1,7 @@
+export function extractElement (array, predicate) {
+    const index = array.findIndex(predicate)
+    if (index === -1) {
+        return [ null, array ]
+    }
+    return [array[index], [...array.slice(0, index), ...array.slice(index + 1)]]
+}


### PR DESCRIPTION
## Description

This plugin will find all the tags found in the markdown files (following`(displayed text|keyword):{{#tag name}}` syntax), and create corresponding nodes in the data layer. If `|keyword` is ommited, the display text will be used as a keyword.

It will not clean up stale data on multiple runs, so expect some pollution when hot-rebuilding pages.

`gatsby-plugin-mdx` version was bumped up to allow proper processing of the plugin's `gatsby-node.js`.

## Linked issues

Resolves #9 
